### PR TITLE
Remove redundant semicolon

### DIFF
--- a/src/rtl/prince_core.v
+++ b/src/rtl/prince_core.v
@@ -300,7 +300,7 @@ module prince_core(
 
   function [63 : 0] round11(input [63 : 0] b, input [63 : 0] k);
     begin
-      round11 =  b ^ k ^ rc(11);;
+      round11 =  b ^ k ^ rc(11);
     end
   endfunction // round11
 


### PR DESCRIPTION
Hi,

Thanks for your implementation of the Prince block cipher! I tried it in my own Verilog project with the free edition of ModelSim from Intel (version 2020.1), and it threw an error for this redundant semicolon. Hence this little pull request to remove it.

Cheers,
Marco