### PR TITLE
Updated core file with entries required for FuseSoC package database

### DIFF
--- a/prince.core
+++ b/prince.core
@@ -1,6 +1,8 @@
 CAPI=2:
 
-name : secworks:crypto:prince:0
+name: secworks:crypto:prince:1.0.0
+description: The Prince lightweight block cipher in Verilog.
+license: BSD-2-Clause
 
 filesets:
   rtl:


### PR DESCRIPTION
 - Added semantic version
 - Added description
 - Added license SPDX

Chose version 1.0.0 as I could not find a tag and the core is marked as complete.
